### PR TITLE
Added right side widget panel and reusable widget cards

### DIFF
--- a/rocky-interface/src/lib/components/shell/WidgetCard.svelte
+++ b/rocky-interface/src/lib/components/shell/WidgetCard.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	export let title: string;
+</script>
+
+<div class="widget-card">
+	<h3>{title}</h3>
+	<div class="widget-content">
+		<slot />
+	</div>
+</div>

--- a/rocky-interface/src/lib/components/shell/WidgetPanel.svelte
+++ b/rocky-interface/src/lib/components/shell/WidgetPanel.svelte
@@ -1,0 +1,24 @@
+<script>
+	import WidgetCard from './WidgetCard.svelte';
+</script>
+
+<div class="widget-panel">
+
+	<h2 class="widget-panel-title">Widgets</h2>
+
+<WidgetCard title="Analytics">
+	<p>Total System Usage: 98%</p>
+	<p>Active Requests: 42</p>
+	<p>System Temp: 77deg</p>
+</WidgetCard>
+
+<WidgetCard title="System Info">
+	<p>Limit Usage: 88%</p>
+	<p>Courses: 3</p>
+</WidgetCard>
+
+<WidgetCard title="Notifications">
+	<p>No new Notifications</p>
+</WidgetCard>
+
+</div>

--- a/rocky-interface/src/lib/styles/widget-panel.css
+++ b/rocky-interface/src/lib/styles/widget-panel.css
@@ -1,0 +1,47 @@
+.page-layout {
+	display: flex;
+	height: 100%;
+	width: 100%;
+}
+
+.main-content {
+	flex: 1;
+	padding: 32px;
+	overflow-y: auto;
+	min-width: 0;
+}
+
+.widget-panel {
+	width: 300px;
+	min-width: 300px;
+	height: 100%;
+	background: #f3f4f6;
+	border-left: 1px solid #d1d5db;
+	padding: 20px 16px;
+	box-sizing: border-box;
+	overflow-y: auto;
+}
+
+.widget-card {
+	background: white;
+	border-radius: 10px;
+	padding: 16px;
+	margin-bottom: 16px;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.widget-card h3 {
+	margin: 0 0 12px 0;
+	font-size: 1rem;
+}
+
+.widget-card p {
+	margin: 8px 0;
+	line-height: 1.4;
+}
+
+.widget-panel-title {
+	margin: 0 0 16px 0;
+	font-size: 1.1rem;
+	font-weight: 700;
+}

--- a/rocky-interface/src/routes/+page.svelte
+++ b/rocky-interface/src/routes/+page.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
 	import { currentFrame, frameMap, type frameName } from '$lib/stores/frameStore';
+	import WidgetPanel from '$lib/components/shell/WidgetPanel.svelte';
+	import '$lib/styles/widget-panel.css';
 </script>
 
-<svelte:component this={frameMap[$currentFrame as frameName]} />
+<div class="page-layout">
+	<div class="main-content">
+		<svelte:component this={frameMap[$currentFrame as frameName]} />
+	</div>
+	<WidgetPanel />
+</div>


### PR DESCRIPTION
Adds the right side widget panel to the dashboard layout.

The widget panel currently has some basic cards:
- Analytics
- System Info
- Notifications

<img width="1467" height="809" alt="Screenshot 2026-03-16 at 12 14 26 AM" src="https://github.com/user-attachments/assets/b4072c55-4e54-4ea7-b232-d5f20c9ee7aa" />
